### PR TITLE
fix: 修复 axios delete方法的参数错误

### DIFF
--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -61,7 +61,7 @@ const service = {
   },
 
   delete<T = any>(url: string, data?: object): Promise<T> {
-    return axiosInstance.delete(url, data);
+    return axiosInstance.delete(url, { data });
   },
 
   upload: (url: string, file: FormData | File) =>


### PR DESCRIPTION
delete方法的第二个参数应该是config，这里直接把data作为第二个参数传进去了
![1687417852955](https://github.com/nekobc1998923/vitecamp/assets/57349905/3b73a746-301a-4aa0-86c3-f18e8f4870cb)
![1687417895852](https://github.com/nekobc1998923/vitecamp/assets/57349905/c8e5ec1d-8f45-49bf-b002-b3bd797e1467)
